### PR TITLE
Fix panic when status code is nil after error and force UTC for event times

### DIFF
--- a/log/http_test.go
+++ b/log/http_test.go
@@ -17,8 +17,8 @@ func TestHTTP(t *testing.T) {
 		So(http, ShouldImplement, (*option)(nil))
 
 		Convey("*EventHTTP has the correct fields", func() {
-			startTime := time.Now().Add(time.Second * -1)
-			endTime := time.Now()
+			startTime := time.Now().UTC().Add(time.Second * -1)
+			endTime := time.Now().UTC()
 			duration := endTime.Sub(startTime)
 
 			http := HTTP(req, 101, 123, &startTime, &endTime)
@@ -53,7 +53,7 @@ func TestHTTP(t *testing.T) {
 	})
 
 	Convey("Duration should be nil if startedAt is nil", t, func() {
-		endTime := time.Now()
+		endTime := time.Now().UTC()
 		http := HTTP(req, 101, 123, nil, &endTime)
 		httpEvent := http.(*EventHTTP)
 
@@ -61,7 +61,7 @@ func TestHTTP(t *testing.T) {
 	})
 
 	Convey("Duration should be nil if endedAt is nil", t, func() {
-		startTime := time.Now()
+		startTime := time.Now().UTC()
 		http := HTTP(req, 101, 123, &startTime, nil)
 		httpEvent := http.(*EventHTTP)
 

--- a/log/log.go
+++ b/log/log.go
@@ -173,7 +173,7 @@ func eventWithoutOptionsCheck(ctx context.Context, event string, opts ...option)
 // createEvent creates a new event struct and attaches the options to it
 func createEvent(ctx context.Context, event string, opts ...option) *EventData {
 	e := EventData{
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 		Namespace: Namespace,
 		Event:     event,
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -158,7 +158,7 @@ func TestLog(t *testing.T) {
 			evt := createEvent(nil, "event")
 			So(evt.CreatedAt.Unix(), ShouldBeGreaterThan, 0)
 
-			now := time.Now()
+			now := time.Now().UTC()
 			diff := now.Sub(evt.CreatedAt)
 			// if this starts failing, and the code hasn't changed, check that
 			// the two lines above actually take less than 100 milliseconds

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -33,8 +33,14 @@ func Middleware(f http.Handler) http.Handler {
 		Event(req.Context(), "http request received", HTTP(req, 0, 0, &start, nil))
 
 		defer func() {
-			end := time.Now()
-			Event(req.Context(), "http request completed", HTTP(req, *rc.statusCode, rc.bytesWritten, &start, &end))
+			end := time.Now().UTC()
+
+			statusCode := 0
+			if rc.statusCode != nil {
+				statusCode = *rc.statusCode
+			}
+
+			Event(req.Context(), "http request completed", HTTP(req, statusCode, rc.bytesWritten, &start, &end))
 		}()
 
 		f.ServeHTTP(rc, req)

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -29,7 +29,7 @@ func Middleware(f http.Handler) http.Handler {
 		}
 
 		rc := &responseCapture{w, nil, 0}
-		start := time.Now()
+		start := time.Now().UTC()
 		Event(req.Context(), "http request received", HTTP(req, 0, 0, &start, nil))
 
 		defer func() {


### PR DESCRIPTION
### What

* Panic that occurred in the middleware due to nil pointer dereference when the status code was not set after an error.
* Force UTC time for all log events inline with the logging spec.

### Who can review

Anyone but me.
