### PR TITLE
Remove travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-log.go [![Build Status](https://travis-ci.org/ONSdigital/log.go.svg?branch=master)](https://travis-ci.org/ONSdigital/log.go) [![GoDoc](https://godoc.org/github.com/ONSdigital/log.go/log?status.svg)](https://godoc.org/github.com/ONSdigital/log.go/log)
+log.go [![GoDoc](https://godoc.org/github.com/ONSdigital/log.go/log?status.svg)](https://godoc.org/github.com/ONSdigital/log.go/log)
 ======
 
 A log library for Go.


### PR DESCRIPTION
### What

Remove travis build status from README.md

### How to review

See that its no longer there.

### Who can review

anyone
