### PR TITLE
Update error function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Opinionated, and designed to match our [logging standards](https://github.com/ON
 
 ### Licence
 
-Copyright ©‎ 2019-2020, Crown Copyright (Office for National Statistics) (https://www.ons.gov.uk)
+Copyright ©‎ 2019-2021, Crown Copyright (Office for National Statistics) (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/log/error.go
+++ b/log/error.go
@@ -32,7 +32,7 @@ func (l *EventError) attach(le *EventData) {
 	le.Error = l
 }
 
-// Error returns an option you can pass to Event to attach
+// FormatError returns an option you can pass to Event to attach
 // error information to a log event
 //
 // It uses error.Error() to stringify the error value
@@ -41,10 +41,10 @@ func (l *EventError) attach(le *EventData) {
 // data. For a struct{} type, it is included directly. For all
 // other types, it is wrapped in a Data{} struct
 //
-// It also includes a full strack trace to where Error() is called,
+// It also includes a full strack trace to where FormatError() is called,
 // so you shouldn't normally store a log.Error for reuse (e.g. as a
 // package level variable)
-func Error(err error) option {
+func FormatError(err error) option {
 	e := &EventError{
 		Message:    err.Error(),
 		StackTrace: make([]EventStackTrace, 0),

--- a/log/error_test.go
+++ b/log/error_test.go
@@ -23,13 +23,13 @@ func (c customIntError) Error() string {
 
 func TestError(t *testing.T) {
 	Convey("Error function returns a *EventError", t, func() {
-		err := Error(errors.New("test"))
+		err := FormatError(errors.New("test"))
 		So(err, ShouldHaveSameTypeAs, &EventError{})
 		So(err, ShouldImplement, (*option)(nil))
 
 		Convey("*EventError has the correct fields", func() {
 			myErr := errors.New("test error")
-			ee := Error(myErr).(*EventError)
+			ee := FormatError(myErr).(*EventError)
 			So(ee.Message, ShouldEqual, "test error")
 			So(ee.Data, ShouldResemble, myErr)
 			So(ee.StackTrace, ShouldHaveLength, 10)
@@ -48,28 +48,28 @@ func TestError(t *testing.T) {
 
 	Convey("Message function sets *EventError.Message to error.Message()", t, func() {
 		err := errors.New("test error")
-		errEventData := Error(err).(*EventError)
+		errEventData := FormatError(err).(*EventError)
 		So(errEventData.Message, ShouldEqual, "test error")
 
 		err = customError{"goodbye"}
-		errEventData = Error(err).(*EventError)
+		errEventData = FormatError(err).(*EventError)
 		So(errEventData.Message, ShouldEqual, "hi there!")
 	})
 
 	Convey("Message function sets *EventError.Data to error", t, func() {
 		Convey("A value of kind 'Struct' is embedded directly", func() {
 			err := customError{}
-			errEventData := Error(err).(*EventError)
+			errEventData := FormatError(err).(*EventError)
 			So(errEventData.Data, ShouldHaveSameTypeAs, err)
 		})
 		Convey("A value of kind 'Ptr->Struct' is embedded directly", func() {
 			err := &customError{}
-			errEventData := Error(err).(*EventError)
+			errEventData := FormatError(err).(*EventError)
 			So(errEventData.Data, ShouldEqual, err)
 		})
 		Convey("A value of other kinds (e.g. 'Int') is wrapped in Data{value:<err>}", func() {
 			err := customIntError(0)
-			errEventData := Error(err).(*EventError)
+			errEventData := FormatError(err).(*EventError)
 			So(errEventData.Data, ShouldHaveSameTypeAs, Data{})
 			So(errEventData.Data.(Data)["value"], ShouldHaveSameTypeAs, customIntError(0))
 		})
@@ -78,7 +78,7 @@ func TestError(t *testing.T) {
 	Convey("Message function generates a stack trace", t, func() {
 		err := errors.New("new error")
 		// WARNING if this line moves, update `So(origin.Line, ...)` below
-		errEventData := Error(err).(*EventError)
+		errEventData := FormatError(err).(*EventError)
 		So(errEventData.StackTrace, ShouldHaveLength, 10)
 		origin := errEventData.StackTrace[0]
 		So(origin.File, ShouldEndWith, "log.go/log/error_test.go")

--- a/log/log.go
+++ b/log/log.go
@@ -71,30 +71,26 @@ func Event(ctx context.Context, event string, severity severity, opts ...option)
 	eventFuncInst.f(ctx, event, severity, opts...)
 }
 
-//log.Info wraps the Event function with the severity level set to INFO
+// Info wraps the Event function with the severity level set to INFO
 func Info(ctx context.Context, event string, opts ...option) {
 	eventFuncInst.f(ctx, event, INFO, opts...)
 }
 
-//log.Warn wraps the Event function with the severity level set to WARN
+// Warn wraps the Event function with the severity level set to WARN
 func Warn(ctx context.Context, event string, opts ...option) {
 	eventFuncInst.f(ctx, event, WARN, opts...)
 }
 
-//log.ErrorDetails wraps the Event function with the severity level set to ERROR
-func ErrorDetails(ctx context.Context, event string, err error, opts ...option) {
-	errs := &EventError{
-		Message: err.Error(),
-	}
+// Error wraps the Event function with the severity level set to ERROR
+func Error(ctx context.Context, event string, err error, opts ...option) {
+	errs := FormatError(err)
 	opts = append(opts, errs)
 	eventFuncInst.f(ctx, event, ERROR, opts...)
 }
 
-//log.Fatal wraps the Event function with the severity level set to FATAL
+// Fatal wraps the Event function with the severity level set to FATAL
 func Fatal(ctx context.Context, event string, err error, opts ...option) {
-	errs := &EventError{
-		Message: err.Error(),
-	}
+	errs := FormatError(err)
 	opts = append(opts, errs)
 	eventFuncInst.f(ctx, event, FATAL, opts...)
 }
@@ -236,7 +232,7 @@ func handleStyleError(ctx context.Context, e EventData, ef eventFunc, b []byte, 
 		// note: Message(err) currently ignores this constraint, but it's expected that the `err`
 		// 		 passed in by the caller will have come from json.Marshal or prettyjson.Marshal
 		//       which don't marshal any non-marshallable types anyway
-		ef.f(ctx, "error marshalling event data", ERROR, Error(err), Data{"event_data": fmt.Sprintf("%+v", e)})
+		ef.f(ctx, "error marshalling event data", ERROR, FormatError(err), Data{"event_data": fmt.Sprintf("%+v", e)})
 
 		// if we're in test mode, we'll also panic to cause tests to fail
 		if isTestMode {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -87,38 +87,51 @@ func TestLog(t *testing.T) {
 
 		Convey("Info calls eventFuncInst.f", func() {
 			var wasCalled bool
+			var severityLevel severity
 			eventFuncInst = &eventFunc{func(ctx context.Context, event string, severity severity, opts ...option) {
 				wasCalled = true
+				severityLevel = severity
 			}}
 			Info(nil, "", INFO)
 			So(wasCalled, ShouldBeTrue)
+			So(severityLevel, ShouldEqual, INFO)
 		})
 
 		Convey("Warn calls eventFuncInst.f", func() {
 			var wasCalled bool
+			var severityLevel severity
 			eventFuncInst = &eventFunc{func(ctx context.Context, event string, severity severity, opts ...option) {
 				wasCalled = true
+				severityLevel = severity
 			}}
 			Warn(nil, "", WARN)
 			So(wasCalled, ShouldBeTrue)
+			So(severityLevel, ShouldEqual, WARN)
 		})
 
-		Convey("ErrorDetails calls eventFuncInst.f", func() {
+		Convey("Error calls eventFuncInst.f", func() {
 			var wasCalled bool
+			var severityLevel severity
 			eventFuncInst = &eventFunc{func(ctx context.Context, event string, severity severity, opts ...option) {
 				wasCalled = true
+				severityLevel = severity
 			}}
-			ErrorDetails(nil, "", errors.New("error"), ERROR)
+			Error(nil, "", errors.New("error"))
 			So(wasCalled, ShouldBeTrue)
+			So(severityLevel, ShouldEqual, ERROR)
+
 		})
 
 		Convey("Fatal calls eventFuncInst.f", func() {
 			var wasCalled bool
+			var severityLevel severity
 			eventFuncInst = &eventFunc{func(ctx context.Context, event string, severity severity, opts ...option) {
 				wasCalled = true
+				severityLevel = severity
 			}}
 			Fatal(nil, "", errors.New("fatal error"), FATAL)
 			So(wasCalled, ShouldBeTrue)
+			So(severityLevel, ShouldEqual, FATAL)
 		})
 
 		Convey("styler function is set correctly", func() {

--- a/scripts/test-update-logs.go
+++ b/scripts/test-update-logs.go
@@ -16,13 +16,13 @@ func main() {
 	// comment above each one with the exception that err is reffered to as error
 
 	// log.Event(ctx, , log.Message(error))
-	log.Error(err)
+	log.FormatError(err)
 
 	// log.Event(ctx, , log.Message(error), logData)
-	log.Error(err)
+	log.FormatError(err)
 
 	// log.Event(ctx, , log.Message(error), log.Data{"data_1": data1})
-	log.Error(err)
+	log.FormatError(err)
 
 	// log.Event(ctx, "message", )
 	log.Info(ctx, "message", nil)


### PR DESCRIPTION
### What

Rename Error function to FormatError, and rename ErrorDetails function to Error so that the naming is more consistent with the new severity logging functions added (Info, Warn and Fatal)

### How to review

Confirm changes are correct

### Who can review

Anyone
