### PR TITLE
add refactor-go-logging.sh to scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+This directory contains scripts for refactoring logging statements in .go files.
+
+# Historical logging refactoring: go-ns -> log.go
+
+The file `edit-logs.sh` is from an earlier logging exercise. It refactors from the older `go-ns` logging library to the newer `log.go`, and updates logging statement syntax to match.
+
+## Usage
+
+Execute as `<path to>edit-logs.sh <target directory>`
+
+`edit-logs.sh` will then scan `<target directory>` for .go files, and in-place modify each one found to:
+- update logging imports from `go-ns` to `log.go`
+- update logging statements to newer syntax (run `edit-logs.sh -h` or read the file itself for more details)
+
+The script can be tested by running against this directory. You should see the file `test-update-logs.go` altered so that the logging statements match those stated in the comments immediately above each one.
+
+# Logging refactoring June/July 2021: log.go v1 -> log.go v2
+
+The file `refactor-go-logging.sh` is from a refactoring exercise run in June/July 2021. It refactors from the older `log.go v1` to the newer `log.go v2`, and updates logging statement syntax to match.
+
+## Usage (single file)
+
+Execute as `<path to>refactor-go-logging.sh < <target file> > <output file>` (note use of single `<` and `>` denote streaming from / to files here, not user-defined input)
+
+`refactor-go-logging.sh` will create `<output file>`, which contains the content of `<target file>` modified as so:
+- update logging imports from `log.go` to `log.go/v2`
+- update logging statements to newer syntax, e.g.:
+```go
+log.Event(ctx, string, log.FATAL, log.Error(something1), something2)
+	-> log.Fatal(ctx, string, something1, something2)
+
+log.Event(ctx, string, log.ERROR log.Error(something1), something2)
+	-> log.Error(ctx, string, something1, something2)
+
+log.Event(ctx, string, log.INFO, something)
+	-> log.Info(ctx, string, something)
+
+log.Event(ctx, string, log.WARN, log.Error(something), something2)
+	-> log.Warn(ctx, string, log.FormatErrors([]error{something}), something2)
+```
+
+## Usage (directory)
+
+The script `refactor-all-go-logging-in-directory.sh` is a wrapper for `refactor-go-logging.sh` which runs it to in-place modify all .go files in `<target directory>`, similar to the original `edit-logs.sh`.
+
+Execute as `<path to>refactor-all-go-logging-in-directory.sh <target directory>`
+
+`refactor-all-go-logging-in-directory.sh` will then scan a target directory for .go files, and in-place modify each one found using the `refactor-go-logging.sh` script.

--- a/scripts/refactor-all-go-logging-in-directory.sh
+++ b/scripts/refactor-all-go-logging-in-directory.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Runs sed script refactor-go-logging.sh against all .go files found in TARGET_DIR given as argument $1
+# NB: will edit all files in place!
+
+THIS_DIR=$(realpath $(dirname $0))
+TARGET_DIR=$1
+find ${TARGET_DIR} -type f -name "*.go" -print0 | while read -d $'\0' file
+do
+  ${THIS_DIR}/refactor-go-logging.sh < ${file} > ${file}.new && mv ${file}.new ${file}
+done
+

--- a/scripts/refactor-go-logging.sh
+++ b/scripts/refactor-go-logging.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Author: Daniel Lawrence (@wavemechanics)
+# Sed script to refactor log.go import and logging statements in .go files to match new syntax.
+# Note: the log.Error(x) -> log.FormatErrors([]error{x})
+# mapping is slightly fragile.
+# If "x" has nested parens or anything complicated, it may
+# not work.
+# Seems to work on the cases I have run across, but sometimes
+# this is only by accident.
+# I figure special cases can be fixed by hand.
+
+sed -E -e '
+:top
+    # Skip any substitutions on comment lines
+    #
+    /^[[:blank:]]*\/\//{
+        n
+        b top
+    }
+
+
+    # FATAL events are mapped like this:
+    #
+    # log.Event(ctx, string, log.FATAL, log.Error(something1), something2) -> log.Fatal(ctx, string, something1, something2)
+    #
+    /log\.Event.*log\.FATAL/{
+
+        # change the function name
+        s/log\.Event/log.Fatal/
+
+        # remove the severity
+        s/,[[:blank:]]*log.FATAL//
+
+        # extract the log.Error argument
+        s/log.Error\(([^)]*)\)/\1/
+
+        # and go to the next line
+        n
+        b top
+    }
+
+    # And ERROR events are similar:
+    #
+    # log.Event(ctx, string, log.ERROR log.Error(something1), something2) -> log.Error(ctx, string, something1, something2)
+    #
+    /log\.Event.*log\.ERROR/{
+
+        # remove the severity
+        s/,[[:blank:]]*log.ERROR//
+
+        # extract the log.Error argument
+        s/log.Error\(([^)]*)\)/\1/
+
+        # change the function name
+        s/log\.Event/log.Error/
+
+        # and go to the next line
+        n
+        b top
+    }
+
+    # Info events are mapped like this:
+    #
+    # log.Event(ctx, string, log.INFO, log.Error(something)) -> log.Info(ctx, string, log.FormatErrors([]error{something}))
+    #
+    /log\.Event.*log.INFO/{
+
+        # remove the severity
+        s/,[[:blank:]]*log.INFO//
+
+        # Change .Error to .FormatErrors
+        s/log\.Error\(([^)]*)\)/log.FormatErrors([]error{\1})/
+
+        # change the function name
+        s/log\.Event/log.Info/
+
+        # and go to the next line
+        n
+        b top
+    }
+
+    # Warn events are mapped like info:
+    #
+    # log.Event(ctx, string, log.WARN, log.Error(something)) -> log.Warn(ctx, string, log.FormatErrors([]error{something}))
+    #
+    /log\.Event.*log.WARN/{
+
+        # remove the severity
+        s/,[[:blank:]]*log.WARN//
+
+        # Change .Error to .FormatErrors
+        s/log\.Error\(([^)]*)\)/log.FormatErrors([]error{\1})/
+
+        # change the function name
+        s/log\.Event/log.Warn/
+
+        # and go to the next line
+        n
+        b top
+    }
+
+    # outdated log module version imports are mapped like this:
+    #
+    # "github.com/ONSdigital/log.go/log" -> "github.com/ONSdigital/log.go/v2/log"
+    # "github.com/ONSdigital/log.go/v1/log" -> "github.com/ONSdigital/log.go/v2/log"
+    #
+    /"github.com\/ONSdigital\/log.go.*\/log"/{
+
+        # Change whatever is between log.go and /log with /v2
+        s/log.go.*\/log/log.go\/v2\/log/
+
+        # and go to the next line
+        n
+        b top
+    }
+'


### PR DESCRIPTION
### What

Add following to scripts dir
- refactor-go-logging.sh, updated log import / statement refactoring
script for log.go v2
- refactor-all-go-logging-in-directory.sh, runs refactor-go-logging.sh
against all .go files in a target directory
- README

These changes needed to facilitate updates of existing go files
to use new log.go v2 syntax, and to allow better parsing of
resulting logs by elastisearch.

### How to review

- check the new script works, both run singly and with the runner script
- check the readme makes sense
- check code is readable 

### Who can review

Anyone