### PR TITLE
Errors now mapped to `errors` in json tag

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -172,7 +172,7 @@ type EventData struct {
 	Data *Data      `json:"data,omitempty"`
 
 	// Error data
-	Errors *EventErrors `json:"error,omitempty"`
+	Errors *EventErrors `json:"errors,omitempty"`
 }
 
 // eventWithOptionsCheck is the event function used when running tests, and


### PR DESCRIPTION
### What

See title

### How to review

Check the error/fatal logs a structure containing `errors` field instead of `error` - you can do this by changing go.mod file locally using `replace github.com/ONSdigital/log.go/v2 => ../log.go`

### Who can review

Anyone
