### PR TITLE
Namespace defaults to last element of path given as os.Args[0]

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"reflect"
 	"strconv"
 	"time"
@@ -19,7 +20,7 @@ import (
 //
 // It defaults to the application binary name, but this should
 // normally be set to a more sensible name on application startup
-var Namespace = os.Args[0]
+var Namespace = path.Base(os.Args[0])
 
 var destination io.Writer = os.Stdout
 var fallbackDestination io.Writer = os.Stderr

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -29,8 +30,8 @@ func TestLog(t *testing.T) {
 	t.Parallel()
 
 	Convey("Package defaults are right", t, func() {
-		Convey("Namespace defaults to os.Args[0]", func() {
-			So(Namespace, ShouldEqual, os.Args[0])
+		Convey("Namespace defaults to last element of path supplied as os.Args[0]", func() {
+			So(Namespace, ShouldEqual, path.Base(os.Args[0]))
 		})
 
 		Convey("destination defaults to os.Stdout", func() {


### PR DESCRIPTION
### What

Namespace defaults to path.Base(os.Args[0]), i.e. the last element
of the path used to invoke the binary, rather than plain os.Args[0].

This change needed to avoid situtations where an app is using multiple
versions of log.go, but only one version has the Namespace var set
(generally the one that is used in main.go), and the other version(s)
of log.go use the default os.Args[0]. This has resulted in apps logging
to different namespaces, e.g. MyApp and ./MyApp, depending on which
version of log.go is doing the logging.

### How to review

- eyeball changes
- run make test (the `TestLog.Package defaults are right` test has been modified to assert the new default value is as expected)

### Who can review

Anyone
