### PR TITLE
add realpath function in log script

### DIFF
--- a/scripts/refactor-all-go-logging-in-directory.sh
+++ b/scripts/refactor-all-go-logging-in-directory.sh
@@ -3,6 +3,20 @@
 # Runs sed script refactor-go-logging.sh against all .go files found in TARGET_DIR given as argument $1
 # NB: will edit all files in place!
 
+realpath ()                                                                                                                                                                                   
+{                                                                                                                                                                                             
+    f=$@;                                                                                                                                                                                     
+    if [ -d "$f" ]; then                                                                                                                                                                      
+        base="";                                                                                                                                                                              
+        dir="$f";                                                                                                                                                                             
+    else                                                                                                                                                                                      
+        base="/$(basename "$f")";                                                                                                                                                             
+        dir=$(dirname "$f");                                                                                                                                                                  
+    fi;                                                                                                                                                                                       
+    dir=$(cd "$dir" && /bin/pwd);                                                                                                                                                             
+    echo "$dir$base"                                                                                                                                                                          
+}
+
 THIS_DIR=$(realpath $(dirname $0))
 TARGET_DIR=$1
 find ${TARGET_DIR} -type f -name "*.go" -print0 | while read -d $'\0' file


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Add `realpath` function
- The script `refactor-all-go-logging-in-directory.sh` calls the `realpath` command which the script expects the `realpath` function to exist in developers' local machine
- This change now ensures that this script can be run on any machine regardless of whether the function already exists or not

### How to review
**Describe the steps required to test the changes.**
- Test if the scripts works by running it on an app which uses log.go v1 and see if the log lines have been changed

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone