### PR TITLE
Add new classification field to log event

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ log.Error(context.Background(), "unexpected error", customErr)
   "severity": 1
 }
 ```
+Logging an event with a classification parameter
+```go
+log.Info(context.Background(), "info message with classification", log.Classification(log.ProtectiveMonitoring))
+```
+```json
+{
+  "created_at": "2020-12-10T11:16:39.1564Z",
+  "classification": "PROTECTIVE_MONITORING",
+  "event": "info message with classification",
+  "namespace": "dp-logging-example",
+  "severity": 3
+}
+```
 Full code example:
 ```go
 package main
@@ -237,6 +250,9 @@ func main() {
 
   // Log an error event with additional parameters
   log.Error(context.Background(), "unexpected error", customErr)
+  
+  // Log an error event with classifications
+  log.Info(context.Background(), "info message with classification", log.Classification(log.ProtectiveMonitoring))
 }
 ```
 **Notes:**
@@ -252,6 +268,9 @@ func main() {
 
 - The `log.Event()` interface does not require you to provide a log (severity) level but it's recommended you provide this 
   field if possible/where appropriate. Better yet use the Wrapper functions `log.Info(...)`, `log.Warn(...)`, `log.Error(...)` and `log.Fatal(...)` to inherit log level.
+
+
+- The `log.Classification()` is used to add an optional classification field that are set as consts. Currently the only available classification is `log.ProtectiveMonitoring` which outputs "PROTECTIVE_MONITORING".
 
 ### Scripts
 

--- a/log/classification.go
+++ b/log/classification.go
@@ -1,7 +1,11 @@
 package log
 
-type Classification string
+type classification string
 
-func (c Classification) attach(le *EventData) {
+func (c classification) attach(le *EventData) {
 	le.Classification = string(c)
+}
+
+func Classification(classification classification) option {
+	return classification
 }

--- a/log/classification.go
+++ b/log/classification.go
@@ -1,0 +1,7 @@
+package log
+
+type Classification string
+
+func (c Classification) attach(le *EventData) {
+	le.Classification = string(c)
+}

--- a/log/classification.go
+++ b/log/classification.go
@@ -2,10 +2,14 @@ package log
 
 type classification string
 
+const (
+	ProtectiveMonitoring classification = "PROTECTIVE_MONITORING"
+)
+
 func (c classification) attach(le *EventData) {
-	le.Classification = string(c)
+	le.Classification = c
 }
 
-func Classification(classification classification) option {
-	return classification
+func Classification(c classification) option {
+	return c
 }

--- a/log/classification_test.go
+++ b/log/classification_test.go
@@ -11,9 +11,9 @@ func TestClassification(t *testing.T) {
 		event := &EventData{}
 		So(event.Classification, ShouldBeEmpty)
 
-		classification := Classification("PROTECTIVE_MONITORING")
-		classification.attach(event)
+		opt := Classification("PROTECTIVE_MONITORING")
+		opt.attach(event)
 
-		So(event.Classification, ShouldResemble, string(classification))
+		So(event.Classification, ShouldEqual, "PROTECTIVE_MONITORING")
 	})
 }

--- a/log/classification_test.go
+++ b/log/classification_test.go
@@ -11,9 +11,9 @@ func TestClassification(t *testing.T) {
 		event := &EventData{}
 		So(event.Classification, ShouldBeEmpty)
 
-		opt := Classification("PROTECTIVE_MONITORING")
+		opt := Classification(ProtectiveMonitoring)
 		opt.attach(event)
 
-		So(event.Classification, ShouldEqual, "PROTECTIVE_MONITORING")
+		So(string(event.Classification), ShouldEqual, "PROTECTIVE_MONITORING")
 	})
 }

--- a/log/classification_test.go
+++ b/log/classification_test.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestClassification(t *testing.T) {
+	Convey("Classification can be attached to *EventData", t, func() {
+		event := &EventData{}
+		So(event.Classification, ShouldBeEmpty)
+
+		classification := Classification("PROTECTIVE_MONITORING")
+		classification.attach(event)
+
+		So(event.Classification, ShouldResemble, string(classification))
+	})
+}

--- a/log/log.go
+++ b/log/log.go
@@ -169,10 +169,10 @@ type EventData struct {
 	Event     string    `json:"event"`
 
 	// Optional fields
-	TraceID        string    `json:"trace_id,omitempty"`
-	SpanID         string    `json:"span_id,omitempty"`
-	Severity       *severity `json:"severity,omitempty"`
-	Classification string    `json:"classification,omitempty"`
+	TraceID        string         `json:"trace_id,omitempty"`
+	SpanID         string         `json:"span_id,omitempty"`
+	Severity       *severity      `json:"severity,omitempty"`
+	Classification classification `json:"classification,omitempty"`
 
 	// Optional nested data
 	HTTP *EventHTTP `json:"http,omitempty"`

--- a/log/log.go
+++ b/log/log.go
@@ -169,9 +169,10 @@ type EventData struct {
 	Event     string    `json:"event"`
 
 	// Optional fields
-	TraceID  string    `json:"trace_id,omitempty"`
-	SpanID   string    `json:"span_id,omitempty"`
-	Severity *severity `json:"severity,omitempty"`
+	TraceID        string    `json:"trace_id,omitempty"`
+	SpanID         string    `json:"span_id,omitempty"`
+	Severity       *severity `json:"severity,omitempty"`
+	Classification string    `json:"classification,omitempty"`
 
 	// Optional nested data
 	HTTP *EventHTTP `json:"http,omitempty"`

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -388,13 +388,13 @@ func TestLog(t *testing.T) {
 			So(calledOpts[1], ShouldHaveSameTypeAs, Data{})
 			d := calledOpts[1].(Data)
 			So(d, ShouldContainKey, "event_data")
-			So(d["event_data"], ShouldEqual, "{CreatedAt:0001-01-01 00:00:00 +0000 UTC Namespace: Event: TraceID: SpanID: Severity:<nil> HTTP:<nil> Auth:<nil> Data:<nil> Errors:<nil>}")
+			So(d["event_data"], ShouldEqual, "{CreatedAt:0001-01-01 00:00:00 +0000 UTC Namespace: Event: TraceID: SpanID: Severity:<nil> Classification: HTTP:<nil> Auth:<nil> Data:<nil> Errors:<nil>}")
 		})
 
 		Convey("panic if running in test mode", func() {
 			So(func() {
 				handleStyleError(nil, EventData{}, eventFunc{func(ctx context.Context, event string, severity severity, opts ...option) {}}, []byte("test"), errors.New("test"))
-			}, ShouldPanicWith, "error marshalling event data: {CreatedAt:0001-01-01 00:00:00 +0000 UTC Namespace: Event: TraceID: SpanID: Severity:<nil> HTTP:<nil> Auth:<nil> Data:<nil> Errors:<nil>}")
+			}, ShouldPanicWith, "error marshalling event data: {CreatedAt:0001-01-01 00:00:00 +0000 UTC Namespace: Event: TraceID: SpanID: Severity:<nil> Classification: HTTP:<nil> Auth:<nil> Data:<nil> Errors:<nil>}")
 		})
 	})
 


### PR DESCRIPTION
### What

We need to add a field called classification to the log event so that log events that need to go to the protective monitoring store can be tagged with `PROTECTIVE_MONITORING`

### How to review
make test
Check the changes make sense
Choose a service that uses this library and in the go.mod add the following:
```
replace github.com/ONSdigital/log.go/v2 => <Location of where you have cloned this repo>/log.go
```
Add `log.Classification(log.ProtectiveMonitoring)` to a log line you will be able to view
`make debug` the service
Check the log line has `"classification": "PROTECTIVE_MONITORING",` present
### Who can review

Anyone
